### PR TITLE
🔒 Fix insecure hardcoded API key storage

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -9,6 +9,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +411,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "cocoa"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +618,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -611,6 +657,15 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1303,6 +1358,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
 name = "gio"
 version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,6 +1948,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2632,6 +2706,7 @@ dependencies = [
 name = "olly"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "chrono",
  "cocoa",
  "crossbeam-channel",
@@ -2642,6 +2717,7 @@ dependencies = [
  "keyring",
  "log",
  "objc",
+ "rand 0.8.5",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -2660,6 +2736,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
@@ -3011,6 +3093,18 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
 ]
 
 [[package]]
@@ -5141,6 +5235,16 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -15,8 +15,6 @@ tauri = { version = "2", features = [ "macos-private-api"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 chrono = { version = "0.4", features = ["serde"] }
-objc = "0.2.7"
-cocoa = "0.24"
 reqwest = { version = "0.11", features = ["json", "native-tls-vendored", "stream"] }
 tokio = { version = "1.0", features = ["full"] }
 dotenvy = "0.15"
@@ -31,6 +29,12 @@ tauri-plugin-shell = "2"
 tauri-plugin-http = "2.5.6"
 tauri-plugin-os = "2"
 tauri-plugin-calendar = { path = "tauri-plugin-calendar" }
+aes-gcm = "0.10.3"
+rand = "0.8.5"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc = "0.2.7"
+cocoa = "0.24"
 
 [features]
 # This feature is used for production builds or when a dev server is not specified, DO NOT REMOVE!!

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1339,6 +1339,71 @@ fn get_keys_dir() -> PathBuf {
     PathBuf::from(home).join(".olly").join("keys")
 }
 
+// Helper to manage the encryption master key
+fn get_or_create_master_key() -> Result<[u8; 32], String> {
+    use std::fs;
+    use rand::RngCore;
+
+    let keys_dir = get_keys_dir();
+    if let Err(e) = fs::create_dir_all(&keys_dir) {
+        return Err(format!("Failed to create keys directory: {}", e));
+    }
+
+    // Set restrictive permissions on the keys directory
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(metadata) = fs::metadata(&keys_dir) {
+            let mut perms = metadata.permissions();
+            perms.set_mode(0o700);
+            let _ = fs::set_permissions(&keys_dir, perms);
+        }
+    }
+
+    let master_key_path = keys_dir.join(".master.key");
+
+    // If master key exists, read it
+    if master_key_path.exists() {
+        match fs::read(&master_key_path) {
+            Ok(key) => {
+                if key.len() == 32 {
+                    let mut key_arr = [0u8; 32];
+                    key_arr.copy_from_slice(&key);
+                    return Ok(key_arr);
+                } else {
+                    error!("Master key has invalid length (expected 32 bytes)");
+                    // We'll fall through and generate a new one
+                }
+            }
+            Err(e) => {
+                return Err(format!("Failed to read master key: {}", e));
+            }
+        }
+    }
+
+    // Generate new master key
+    info!("Generating new master encryption key");
+    let mut key = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut key);
+
+    // Write new key and set strict permissions
+    match fs::write(&master_key_path, &key) {
+        Ok(_) => {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                if let Ok(metadata) = fs::metadata(&master_key_path) {
+                    let mut perms = metadata.permissions();
+                    perms.set_mode(0o600);
+                    let _ = fs::set_permissions(&master_key_path, perms);
+                }
+            }
+            Ok(key)
+        }
+        Err(e) => Err(format!("Failed to write master key: {}", e)),
+    }
+}
+
 // File-based storage fallback functions
 fn store_api_key_file(provider: &str, api_key: &str) -> Result<(), String> {
     use std::fs;
@@ -1356,15 +1421,25 @@ fn store_api_key_file(provider: &str, api_key: &str) -> Result<(), String> {
     }
     info!("Keys directory created/exists");
 
-    // Simple XOR encoding for basic obfuscation (not real security)
-    let encoded_key = simple_encode(api_key);
-    info!("Encoded key for storage");
+    // Secure AES-256-GCM encryption
+    let encoded_key = encrypt_api_key(api_key)?;
+    info!("Encrypted key for storage");
 
     let key_file = keys_dir.join(format!("{}.key", provider));
     info!("Writing to file: {:?}", key_file);
 
     match fs::write(&key_file, &encoded_key) {
         Ok(_) => {
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                if let Ok(metadata) = fs::metadata(&key_file) {
+                    let mut perms = metadata.permissions();
+                    perms.set_mode(0o600);
+                    let _ = fs::set_permissions(&key_file, perms);
+                }
+            }
+
             info!("Successfully wrote key file for {}", provider);
             // Verify by reading it back
             match fs::read(&key_file) {
@@ -1405,7 +1480,7 @@ fn get_api_key_file(provider: &str) -> Result<Option<String>, String> {
 
     match fs::read(&key_file) {
         Ok(encoded_data) => {
-            let decoded_key = simple_decode(&encoded_data);
+            let decoded_key = decrypt_api_key(&encoded_data)?;
             Ok(Some(decoded_key))
         }
         Err(e) => Err(format!("Failed to read key file: {}", e)),
@@ -1431,24 +1506,52 @@ fn delete_api_key_file(provider: &str) -> Result<(), String> {
     }
 }
 
-// Simple encoding/decoding for basic obfuscation
-fn simple_encode(input: &str) -> Vec<u8> {
-    let key = b"olly_secure_2024"; // Simple XOR key
-    input
-        .bytes()
-        .enumerate()
-        .map(|(i, b)| b ^ key[i % key.len()])
-        .collect()
+// Secure encryption using AES-256-GCM
+fn encrypt_api_key(input: &str) -> Result<Vec<u8>, String> {
+    use aes_gcm::{
+        aead::{Aead, AeadCore, KeyInit},
+        Aes256Gcm, Key,
+    };
+
+    let master_key_bytes = get_or_create_master_key()?;
+    let key = Key::<Aes256Gcm>::from_slice(&master_key_bytes);
+    let cipher = Aes256Gcm::new(key);
+
+    let nonce = Aes256Gcm::generate_nonce(&mut rand::thread_rng()); // 96-bits; unique per message
+
+    let ciphertext = cipher
+        .encrypt(&nonce, input.as_bytes())
+        .map_err(|e| format!("Encryption failed: {}", e))?;
+
+    // Prepend nonce to the ciphertext
+    let mut result = nonce.to_vec();
+    result.extend_from_slice(&ciphertext);
+    Ok(result)
 }
 
-fn simple_decode(input: &[u8]) -> String {
-    let key = b"olly_secure_2024"; // Same XOR key
-    let decoded: Vec<u8> = input
-        .iter()
-        .enumerate()
-        .map(|(i, &b)| b ^ key[i % key.len()])
-        .collect();
-    String::from_utf8(decoded).unwrap_or_default()
+// Secure decryption using AES-256-GCM
+fn decrypt_api_key(input: &[u8]) -> Result<String, String> {
+    use aes_gcm::{
+        aead::{Aead, KeyInit},
+        Aes256Gcm, Key, Nonce,
+    };
+
+    if input.len() < 12 {
+        return Err("Invalid ciphertext length".to_string());
+    }
+
+    let master_key_bytes = get_or_create_master_key()?;
+    let key = Key::<Aes256Gcm>::from_slice(&master_key_bytes);
+    let cipher = Aes256Gcm::new(key);
+
+    let (nonce_bytes, ciphertext) = input.split_at(12);
+    let nonce = Nonce::from_slice(nonce_bytes);
+
+    let plaintext_bytes = cipher
+        .decrypt(nonce, ciphertext)
+        .map_err(|e| format!("Decryption failed: {}", e))?;
+
+    String::from_utf8(plaintext_bytes).map_err(|e| format!("Invalid UTF-8 in decrypted data: {}", e))
 }
 
 fn load_api_key(_app: &tauri::AppHandle, provider: &str) -> Result<String, String> {


### PR DESCRIPTION
🎯 **What:** 
Replaced the insecure, hardcoded XOR cipher (`simple_encode` and `simple_decode`) used to obfuscate API keys before writing them to disk. Instead, the application now securely encrypts credentials using AES-256-GCM. 

A cryptographically secure 256-bit master key is generated on the first run, stored locally, and used alongside a random 96-bit nonce for each encryption operation. Furthermore, all `.key` files and the `.master.key` file are strictly protected using OS-level permissions (e.g., `chmod 600` on Unix platforms) to prevent unauthorized access by other local users.

⚠️ **Risk:** 
The previous implementation relied on 'security by obscurity', obfuscating API keys using a static, hardcoded key (`b"olly_secure_2024"`). Any user with read access to the `.key` files and the ability to view the application source code could trivially reverse the obfuscation and extract highly sensitive API credentials, potentially resulting in unauthorized usage and financial loss for the user.

🛡️ **Solution:**
1. Replaced the `simple_encode`/`simple_decode` functions with robust `encrypt_api_key`/`decrypt_api_key` functions.
2. Implemented `get_or_create_master_key` to securely manage a per-installation 256-bit AES master key.
3. Added the `aes-gcm` and `rand` crates for strong cryptographic primitives.
4. Enforced strict Unix file permissions (`0o600` for files and `0o700` for directories) when storing both the master key and the API key files.

---
*PR created automatically by Jules for task [6449977600583453962](https://jules.google.com/task/6449977600583453962) started by @childreth*