### PR TITLE
🧹 Remove leftover console.log from colorPicker

### DIFF
--- a/src/lib/components/colorPicker.svelte
+++ b/src/lib/components/colorPicker.svelte
@@ -5,7 +5,6 @@
 
   function handleColorChange(event) {
     color = event.target.value;
-    console.log("handleColorChange");
     // Convert hex to HSL and extract hue
     const hexToHSL = (hex) => {
       // Remove the hash if it's there


### PR DESCRIPTION
🎯 **What:** Removed a leftover `console.log("handleColorChange");` in `src/lib/components/colorPicker.svelte`.
💡 **Why:** Development logs left in the code can clutter the console output, which degrades readability and maintainability. Removing it cleans up the codebase.
✅ **Verification:** Verified tests pass and code reviewer gave #Correct# assessment.
✨ **Result:** A cleaner component without unnecessary console logs.

---
*PR created automatically by Jules for task [16150963731225240535](https://jules.google.com/task/16150963731225240535) started by @childreth*