### PR TITLE
Remove Calendar Tool Debug Logs

### DIFF
--- a/src/lib/tools.js
+++ b/src/lib/tools.js
@@ -179,10 +179,6 @@ async function getCalendarEvents(args) {
       events: formattedEvents
     };
 
-    // Log full response for debugging
-    console.log('📅 Calendar tool response:', JSON.stringify(result, null, 2));
-    console.log(`📊 Event breakdown: ${oneTimeEvents.length} one-time, ${recurringEvents.length} recurring`);
-
     return JSON.stringify(result);
 
   } catch (error) {


### PR DESCRIPTION
Removed debug console.logs from `getCalendarEvents` in `src/lib/tools.js` to prevent cluttering logs and avoid potential data leakage of calendar events.

---
*PR created automatically by Jules for task [12848437826089378799](https://jules.google.com/task/12848437826089378799) started by @childreth*