### PR TITLE
🧹 Clean up leftover console.log statements in showDialog

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -256,13 +256,10 @@ let selectedModel = "smollm2:1.7b";
       });
 
       if (Array.isArray(selected)) {
-        console.log("User selected multiple files:", selected);
         // Handle multiple file selection
       } else if (selected === null) {
-        console.log("User cancelled the selection");
         // Handle cancellation
       } else {
-        console.log("User selected a single file:", selected);
         // Handle single file selection
       }
     } catch (error) {


### PR DESCRIPTION
🎯 **What:** Removed leftover debug `console.log` statements from the `showDialog` function inside `src/routes/+page.svelte`.
💡 **Why:** Cleans up the developer output, removing unnecessary logs during standard file selection while preserving error logging, leading to a cleaner and more maintainable frontend file.
✅ **Verification:** Verified visually by reading the file diff. The changes specifically omit three debug logs matching the exact code block specified while ensuring `console.error` remains. Svelte lint checking via `npm run check` is currently not fully executable due to missing dependencies in the CI sandbox (`svelte-kit: not found`), but the changes are syntactically safe (plain text removal).
✨ **Result:** Improved code health with cleaner developer consoles and removed debug cruft from production path.

---
*PR created automatically by Jules for task [9569919882973541652](https://jules.google.com/task/9569919882973541652) started by @childreth*